### PR TITLE
Refactor DistantSpawner to use mesh instancing

### DIFF
--- a/Box Gum Grassy Woodland/GlobalState.swift
+++ b/Box Gum Grassy Woodland/GlobalState.swift
@@ -41,18 +41,14 @@ class GlobalState: ObservableObject {
             anchor: AnchorEntity(world: [0, 0, 0]),
             modelFilenames: configuration.grassPatches.map { ($0.path, Float($0.range.lowerBound)...Float($0.range.upperBound)) },
             scale: configuration.grassScale,
-            spawnCount: configuration.grassSpawnCount,
-            batchSize: 50,
-            delayBetweenBatches: 0.5
+            spawnCount: configuration.grassSpawnCount
         )
 
         grassClosePatchSpawner = DistantSpawner(
             anchor: AnchorEntity(world: [0, 0, 0]),
             modelFilenames: configuration.closeGrassPatches.map { ($0.path, Float($0.range.lowerBound)...Float($0.range.upperBound)) },
             scale: configuration.closeGrassScale,
-            spawnCount: configuration.closeGrassSpawnCount,
-            batchSize: 50,
-            delayBetweenBatches: 0.5
+            spawnCount: configuration.closeGrassSpawnCount
         )
 
 

--- a/Box Gum Grassy Woodland/Spawners/DistantSpawner.swift
+++ b/Box Gum Grassy Woodland/Spawners/DistantSpawner.swift
@@ -1,51 +1,35 @@
-import SwiftUI
 import RealityKit
 import RealityKitContent
+import simd
 
-class DistantSpawner {
+final class DistantSpawner {
     private let translation: SIMD3<Float>
     private let modelFilenames: [(String, ClosedRange<Float>)]
     private let scale: Float
     private let minimumSpacing: Float
     private let center: SIMD3<Float>
     private let anchor: AnchorEntity
-    
-    // New properties for spawnAll parameters
     private let spawnCount: Int
-    private let batchSize: Int
-    private let delayBetweenBatches: TimeInterval
-    
-    // Cache for loaded models
-    private var modelCache: [String: Entity] = [:]
-    
-    // Precomputed weights for model selection
+
+    private var modelCache: [String: ModelEntity] = [:]
+    private var instancedEntities: [String: ModelEntity] = [:]
+    private var storedTransforms: [String: [simd_float4x4]] = [:]
+
     private let weights: [Float]
     private let totalWeight: Float
-    
-    // Grid for spatial partitioning
+
     private var grid: [SIMD2<Int>: [SIMD3<Float>]] = [:]
     private var positionQueue: [(cell: SIMD2<Int>, position: SIMD3<Float>)] = []
     private let gridCellSize: Float
-    
-    // Entity pool for reuse
-    private var entityPool: [String: [Entity]] = [:]
-    
-    // Memory management
-    private let maxPositions: Int = 1000 // Adjust as needed
+    private let maxPositions: Int = 1000
 
-    private var spawnTimer: DispatchSourceTimer?
-    private var remainingSpawnCount: Int = 0
-    
     init(anchor: AnchorEntity,
          modelFilenames: [(String, ClosedRange<Float>)],
          scale: Float = 1.0,
          minimumSpacing: Float = 5.0,
          translation: SIMD3<Float> = .zero,
          center: SIMD3<Float> = .zero,
-         spawnCount: Int,
-         batchSize: Int,
-         delayBetweenBatches: TimeInterval = 0.4) {
-        
+         spawnCount: Int) {
         self.translation = translation
         self.modelFilenames = modelFilenames
         self.scale = scale
@@ -53,36 +37,56 @@ class DistantSpawner {
         self.center = center
         self.anchor = anchor
         self.spawnCount = spawnCount
-        self.batchSize = batchSize
-        self.delayBetweenBatches = delayBetweenBatches
         self.gridCellSize = max(minimumSpacing, 0.001)
-        
-        // Precompute weights
+
         self.weights = modelFilenames.map { Float($0.1.upperBound - $0.1.lowerBound) }
         self.totalWeight = weights.reduce(0, +)
-        
-        // Preload entity pool
-        for (filename, _) in modelFilenames {
-            entityPool[filename] = []
-            if let model = try? loadModel(named: filename) {
-                for _ in 0..<batchSize { // Pre-clone for batch size
-                    let clone = model.clone(recursive: true)
-                    clone.isEnabled = false
-                    entityPool[filename]?.append(clone)
-                }
-            }
-        }
     }
-    
+
     func getAnchor() -> AnchorEntity {
-        return anchor
+        anchor
     }
-    
-    func selectRandomModelFilenameAndRange() -> (String, ClosedRange<Float>) {
-        guard !modelFilenames.isEmpty else {
-            fatalError("No model filenames provided.")
+
+    func spawnAll(clearExisting: Bool = true) {
+        if clearExisting {
+            removeAll()
         }
 
+        guard spawnCount > 0, !modelFilenames.isEmpty else {
+            return
+        }
+
+        var transformsByModel: [String: [simd_float4x4]] = clearExisting ? [:] : storedTransforms
+
+        for _ in 0..<spawnCount {
+            let (modelFilename, lodRange) = selectRandomModelFilenameAndRange()
+            let localPosition = generateValidPosition(lodRange: lodRange)
+            let worldPosition = localPosition + translation
+            let scaleFactor = Float.random(in: 0.7...1.2) * scale
+            let transform = makeTransform(for: worldPosition, scale: scaleFactor)
+
+            transformsByModel[modelFilename, default: []].append(transform)
+            addToGrid(position: worldPosition)
+        }
+
+        storedTransforms = transformsByModel
+        applyTransformsToInstances()
+    }
+
+    func removeAll() {
+        storedTransforms.removeAll()
+        grid.removeAll()
+        positionQueue.removeAll()
+
+        for entity in instancedEntities.values {
+            entity.removeFromParent()
+        }
+
+        instancedEntities.removeAll()
+        anchor.children.removeAll(keepCapacity: true)
+    }
+
+    private func selectRandomModelFilenameAndRange() -> (String, ClosedRange<Float>) {
         let randomValue = Float.random(in: 0..<totalWeight)
         var cumulativeWeight: Float = 0.0
 
@@ -93,53 +97,85 @@ class DistantSpawner {
             }
         }
 
-        // Fallback to last model (should rarely happen)
-        return modelFilenames.last!
+        return modelFilenames.last ?? ("", 0...0)
     }
-    
-    func loadModel(named filename: String) throws -> Entity {
-        if let cachedModel = modelCache[filename] {
-            return cachedModel
+
+    private func loadModel(named filename: String) throws -> ModelEntity {
+        if let cached = modelCache[filename] {
+            return cached
         }
+
         let model = try ModelEntity.load(named: filename, in: realityKitContentBundle)
         modelCache[filename] = model
         return model
     }
-    
-    func spawn(at position: SIMD3<Float>? = nil) -> Entity {
-        let (modelFilename, lodRange) = selectRandomModelFilenameAndRange()
-        do {
-            let model = try loadModel(named: modelFilename)
-            let spawnPosition = (position ?? generateValidPosition(lodRange: lodRange)) + translation
-            let entity = createEntityClone(from: model, lodRange: lodRange, position: spawnPosition, filename: modelFilename)
-            addToGrid(position: spawnPosition)
+
+    private func prepareInstancedEntity(for filename: String) throws -> ModelEntity {
+        if let entity = instancedEntities[filename] {
             return entity
-        } catch {
-            fatalError("Failed to load model: \(modelFilename), error: \(error)")
+        }
+
+        let baseModel = try loadModel(named: filename)
+        let instancedEntity = baseModel.clone(recursive: true)
+        instancedEntity.isEnabled = true
+        anchor.addChild(instancedEntity)
+        instancedEntities[filename] = instancedEntity
+        return instancedEntity
+    }
+
+    private func applyTransformsToInstances() {
+        let filenames = Set(storedTransforms.keys).union(instancedEntities.keys)
+
+        for filename in filenames {
+            let transforms = storedTransforms[filename] ?? []
+
+            if transforms.isEmpty {
+                if let entity = instancedEntities[filename] {
+                    entity.components.remove(MeshInstancesComponent.self)
+                    entity.removeFromParent()
+                    instancedEntities.removeValue(forKey: filename)
+                }
+                continue
+            }
+
+            do {
+                let instancedEntity = try prepareInstancedEntity(for: filename)
+                var meshInstances = instancedEntity.components[MeshInstancesComponent.self] ?? MeshInstancesComponent()
+                let instanceData = try LowLevelInstanceData(instanceCount: transforms.count)
+                meshInstances[partIndex: 0] = instanceData
+                instanceData.withMutableTransforms { buffer in
+                    for (index, matrix) in transforms.enumerated() {
+                        buffer[index] = matrix
+                    }
+                }
+                instancedEntity.components.set(meshInstances)
+            } catch {
+                print("Failed to apply mesh instancing for \(filename): \(error)")
+            }
         }
     }
 
-    private func createEntityClone(from model: Entity, lodRange: ClosedRange<Float>, position: SIMD3<Float>, filename: String) -> Entity {
-        if let pool = entityPool[filename], let clone = pool.first(where: { !$0.isEnabled }) {
-            // Reuse from pool
-            let randomScaleFactor = Float.random(in: 0.7...1.2) * scale
-            clone.scale = SIMD3<Float>(repeating: randomScaleFactor)
-            clone.position = position
-            clone.look(at: center, from: position, relativeTo: nil)
-            clone.isEnabled = true
-            return clone
-        } else {
-            // Create new clone if pool is empty
-            let clone = model.clone(recursive: true)
-            let randomScaleFactor = Float.random(in: 0.7...1.2) * scale
-            clone.scale = SIMD3<Float>(repeating: randomScaleFactor)
-            clone.position = position
-            clone.look(at: center, from: position, relativeTo: nil)
-            entityPool[filename, default: []].append(clone)
-            return clone
-        }
+    private func makeTransform(for worldPosition: SIMD3<Float>, scale: Float) -> simd_float4x4 {
+        let rotation = rotationTowardCenter(from: worldPosition)
+        let transform = Transform(scale: SIMD3<Float>(repeating: scale),
+                                  rotation: rotation,
+                                  translation: worldPosition)
+        return transform.matrix
     }
-    
+
+    private func rotationTowardCenter(from worldPosition: SIMD3<Float>) -> simd_quatf {
+        let direction = SIMD3<Float>(center.x - worldPosition.x, 0, center.z - worldPosition.z)
+        let lengthSquared = simd_length_squared(direction)
+
+        guard lengthSquared > 0.0001 else {
+            return simd_quatf(angle: 0, axis: [0, 1, 0])
+        }
+
+        let normalized = normalize(direction)
+        let angle = atan2(normalized.x, normalized.z)
+        return simd_quatf(angle: angle, axis: [0, 1, 0])
+    }
+
     private func generateValidPosition(lodRange: ClosedRange<Float>) -> SIMD3<Float> {
         var position: SIMD3<Float>
         var attempts = 0
@@ -149,19 +185,18 @@ class DistantSpawner {
         } while (!isValidPosition(position) && attempts < 10)
         return position
     }
-    
+
     private func generateRandomPosition(lodRange: ClosedRange<Float>) -> SIMD3<Float> {
         let angle = Float.random(in: 0...(2 * .pi))
         let radius = Float.random(in: lodRange)
-        let (sinAngle, cosAngle) = (sin(angle), cos(angle)) // Compute once
+        let (sinAngle, cosAngle) = (sin(angle), cos(angle))
         return SIMD3<Float>(radius * cosAngle, 0, radius * sinAngle)
     }
-    
+
     private func isValidPosition(_ position: SIMD3<Float>) -> Bool {
         let worldPosition = position + translation
         let baseKey = gridKey(for: worldPosition)
 
-        // Check neighboring grid cells
         for dx in -1...1 {
             for dz in -1...1 {
                 let key = SIMD2<Int>(baseKey.x + dx, baseKey.y + dz)
@@ -177,7 +212,7 @@ class DistantSpawner {
         }
         return true
     }
-    
+
     private func addToGrid(position: SIMD3<Float>) {
         if positionQueue.count >= maxPositions, let oldest = positionQueue.first {
             positionQueue.removeFirst()
@@ -202,66 +237,5 @@ class DistantSpawner {
         let gridX = Int(floor(position.x / gridCellSize))
         let gridZ = Int(floor(position.z / gridCellSize))
         return SIMD2<Int>(gridX, gridZ)
-    }
-    
-    public func spawnAll(clearExisting: Bool = true) {
-        if clearExisting {
-            removeAll()
-        }
-
-        cancelSpawnTimer()
-
-        remainingSpawnCount = spawnCount
-
-        guard remainingSpawnCount > 0 else {
-            return
-        }
-
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
-        timer.schedule(deadline: .now(), repeating: delayBetweenBatches)
-        timer.setEventHandler { [weak self] in
-            guard let self = self else { return }
-
-            guard self.remainingSpawnCount > 0 else {
-                self.cancelSpawnTimer()
-                return
-            }
-
-            let currentBatchSize = min(self.batchSize, self.remainingSpawnCount)
-
-            for _ in 0..<currentBatchSize {
-                let entity = self.spawn()
-                self.anchor.addChild(entity)
-            }
-
-            self.remainingSpawnCount -= currentBatchSize
-
-            if self.remainingSpawnCount <= 0 {
-                self.cancelSpawnTimer()
-            }
-        }
-
-        spawnTimer = timer
-        timer.resume()
-    }
-
-    public func removeAll() {
-        cancelSpawnTimer()
-        remainingSpawnCount = 0
-
-        for entities in entityPool.values {
-            for entity in entities {
-                entity.isEnabled = false // Disable instead of removing
-            }
-        }
-        anchor.children.removeAll(keepCapacity: true)
-        grid.removeAll()
-        positionQueue.removeAll()
-    }
-
-    private func cancelSpawnTimer() {
-        spawnTimer?.setEventHandler(handler: nil)
-        spawnTimer?.cancel()
-        spawnTimer = nil
     }
 }


### PR DESCRIPTION
## Summary
- replace the pooled entity spawning logic with mesh instancing backed by `MeshInstancesComponent`
- cache transforms per model and update instanced entities while preserving distance-based placement
- simplify the global state spawner configuration to match the new initializer

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd2e157f30832bb62e201f012efdc2