### PR TITLE
Fix instancing compatibility in DistantSpawner

### DIFF
--- a/Box Gum Grassy Woodland/GlobalState.swift
+++ b/Box Gum Grassy Woodland/GlobalState.swift
@@ -41,18 +41,14 @@ class GlobalState: ObservableObject {
             anchor: AnchorEntity(world: [0, 0, 0]),
             modelFilenames: configuration.grassPatches.map { ($0.path, Float($0.range.lowerBound)...Float($0.range.upperBound)) },
             scale: configuration.grassScale,
-            spawnCount: configuration.grassSpawnCount,
-            batchSize: 50,
-            delayBetweenBatches: 0.5
+            spawnCount: configuration.grassSpawnCount
         )
 
         grassClosePatchSpawner = DistantSpawner(
             anchor: AnchorEntity(world: [0, 0, 0]),
             modelFilenames: configuration.closeGrassPatches.map { ($0.path, Float($0.range.lowerBound)...Float($0.range.upperBound)) },
             scale: configuration.closeGrassScale,
-            spawnCount: configuration.closeGrassSpawnCount,
-            batchSize: 50,
-            delayBetweenBatches: 0.5
+            spawnCount: configuration.closeGrassSpawnCount
         )
 
 


### PR DESCRIPTION
## Summary
- guard the new mesh instancing path behind a visionOS 2 availability check while keeping the grid placement logic intact
- ensure model clones are strongly typed as `ModelEntity` before configuring instancing and add a fallback clone-based path for older systems
- centralize cleanup of instanced and fallback entities when transforms are cleared or the spawner is reset

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd2e157f30832bb62e201f012efdc2